### PR TITLE
add feature: bulk send by multiple session key in header

### DIFF
--- a/config_test.go
+++ b/config_test.go
@@ -12,7 +12,7 @@ callback:
   connect: "http://localhost:12346/connect"
   receive: "http://localhost:12346/receive"
 `)
-var expectedConfig = Config{
+var TestConfig = Config{
 	Port:          ":12345",
 	SessionHeader: "X-Kuiperbelt-Session-Key",
 	Callback: Callback{
@@ -21,13 +21,13 @@ var expectedConfig = Config{
 	},
 }
 
-func TestConfig(t *testing.T) {
+func TestConfig__Unmarshal(t *testing.T) {
 	c, err := unmarshalConfig(configData)
 	if err != nil {
 		t.Fatal("unexpected error:", err)
 	}
 
-	if reflect.DeepEqual(expectedConfig, *c) {
-		t.Errorf("unexpected config data:\n\t%+v\n\t%+v\n", expectedConfig, *c)
+	if reflect.DeepEqual(TestConfig, *c) {
+		t.Errorf("unexpected config data:\n\t%+v\n\t%+v\n", TestConfig, *c)
 	}
 }

--- a/proxy.go
+++ b/proxy.go
@@ -3,7 +3,6 @@ package kuiperbelt
 import (
 	"bytes"
 	"encoding/json"
-	"gopkg.in/pp.v1"
 	"io"
 	"log"
 	"net/http"
@@ -19,7 +18,6 @@ func (p *Proxy) Register() {
 
 func (p *Proxy) HandlerFunc(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
-	pp.Println(r)
 
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusMethodNotAllowed)

--- a/proxy.go
+++ b/proxy.go
@@ -1,7 +1,11 @@
 package kuiperbelt
 
 import (
+	"bytes"
+	"encoding/json"
+	"gopkg.in/pp.v1"
 	"io"
+	"log"
 	"net/http"
 )
 
@@ -14,32 +18,70 @@ func (p *Proxy) Register() {
 }
 
 func (p *Proxy) HandlerFunc(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
+	pp.Println(r)
+
 	if r.Method != "POST" {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		io.WriteString(w, "Required POST method.")
 		return
 	}
-	key := r.Header.Get(p.Config.SessionHeader)
-	s, err := GetSession(key)
-	if err == sessionNotFoundError {
-		w.WriteHeader(http.StatusNotFound)
+	keys, ok := r.Header[p.Config.SessionHeader]
+	if !ok || len(keys) == 0 {
+		w.WriteHeader(http.StatusBadRequest)
 		io.WriteString(w, "Session is not found.")
 		return
 	}
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, err.Error())
+	ss := make([]Session, 0, len(keys))
+	se := make([]sessionError, 0, len(keys))
+	for _, key := range keys {
+		s, err := GetSession(key)
+		if err != nil {
+			se = append(se, sessionError{err.Error(), key})
+		}
+		ss = append(ss, s)
+	}
+	if len(se) > 0 {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Header().Add("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.Encode(struct {
+			Errors []sessionError `json:"errors"`
+		}{
+			Errors: se,
+		})
 		return
 	}
 
-	_, err = io.Copy(s, r.Body)
-	defer r.Body.Close()
+	b := new(bytes.Buffer)
+	_, err := io.Copy(b, r.Body)
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		io.WriteString(w, err.Error())
-		return
+	}
+	bs := b.Bytes()
+
+	for _, s := range ss {
+		go p.sendMessage(s, bs)
 	}
 
 	w.WriteHeader(http.StatusOK)
-	io.WriteString(w, "OK")
+	io.WriteString(w, `{"result":"OK"}`)
+}
+
+type sessionError struct {
+	Error   string `json:"error"`
+	Session string `json:"session"`
+}
+
+func (p *Proxy) sendMessage(s Session, bs []byte) {
+	nw, err := s.Write(bs)
+	if err != nil {
+		log.Printf("[ERROR] write to session error: session=%s, error=%s\n", s.Key(), err)
+		return
+	}
+	if nw != len(bs) {
+		log.Printf(
+			"[ERROR] write to session is short: session=%s, write_byte=%d, return_byte=%d\n",
+			s.Key(), len(bs), nw,
+		)
+	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -1,0 +1,55 @@
+package kuiperbelt
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyHandlerFunc__BulkSend(t *testing.T) {
+	s1 := &TestSession{new(bytes.Buffer), "hogehoge", false}
+	s2 := &TestSession{new(bytes.Buffer), "fugafuga", false}
+
+	AddSession(s1)
+	AddSession(s2)
+
+	tc := TestConfig
+	p := Proxy{tc}
+	ts := httptest.NewServer(http.HandlerFunc(p.HandlerFunc))
+	defer ts.Close()
+
+	req, err := http.NewRequest("POST", ts.URL, bytes.NewBufferString("test message"))
+	if err != nil {
+		t.Fatal("proxy handler new request unexpected error:", err)
+	}
+	req.Header.Add(tc.SessionHeader, "hogehoge")
+	req.Header.Add(tc.SessionHeader, "fugafuga")
+
+	client := new(http.Client)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatal("proxy handler request unexpected error:", err)
+	}
+	defer resp.Body.Close()
+
+	dec := json.NewDecoder(resp.Body)
+	result := struct {
+		Result string `json:"result"`
+	}{}
+	err = dec.Decode(&result)
+	if err != nil {
+		t.Fatal("proxy handler response unexpected error:", err)
+	}
+	if result.Result != "OK" {
+		t.Fatalf("proxy handler response unexpected response: %+v", result)
+	}
+
+	if s1.String() != "test message" {
+		t.Fatalf("proxy handler s1 not receive message: %s", s1.String())
+	}
+	if s2.String() != "test message" {
+		t.Fatalf("proxy handler s2 not receive message: %s", s2.String())
+	}
+}

--- a/session_test.go
+++ b/session_test.go
@@ -1,0 +1,20 @@
+package kuiperbelt
+
+import (
+	"bytes"
+)
+
+type TestSession struct {
+	*bytes.Buffer
+	key      string
+	isClosed bool
+}
+
+func (s *TestSession) Key() string {
+	return s.key
+}
+
+func (s *TestSession) Close() error {
+	s.isClosed = true
+	return nil
+}


### PR DESCRIPTION
### Usage

1 . start server
```
$ ekbo
```
```
$ plackup sample.psgi -p 12346
```

2 . connect two session
```
## 1
$ wscat -H 'X-Kuiperbelt-Session:hogehoge' -c 'ws://localhost:12345/connect'
< success connect
>
```
```
## 2
$ wscat -H 'X-Kuiperbelt-Session:fugafuga' -c 'ws://localhost:12345/connect'
< success connect
>
```

3 . broadcast message by curl
```
$ curl -d"test message" -H"X-Kuiperbelt-Session:hogehoge" -H"X-Kuiperbelt-Session:fugafuga" http://localhost:12345/send
```

4 . result
```
## 1
< success connect
< test message
```
```
## 2
< success connect
< test message
```