### PR TITLE
[FEATURE] add endpoint header

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,9 @@ package kuiperbelt
 
 import (
 	"io/ioutil"
+	"net"
 	"os"
+	"strconv"
 
 	"gopkg.in/yaml.v1"
 )
@@ -45,7 +47,17 @@ func unmarshalConfig(b []byte) (*Config, error) {
 		if err != nil {
 			return nil, err
 		}
-		config.Endpoint = hostname
+
+		p, err := strconv.Atoi(config.Port)
+		if err != nil {
+			return nil, err
+		}
+
+		if p <= 1023 {
+			config.Endpoint = hostname
+		} else {
+			config.Endpoint = net.JoinHostPort(hostname, config.Port)
+		}
 	}
 
 	return &config, nil

--- a/config.go
+++ b/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	Callback      Callback `yaml:"callback"`
 	SessionHeader string   `yaml:"session_header"`
 	Port          string   `yaml:"port"`
+	Endpoint      string   `yaml:"endpoint"`
 }
 
 type Callback struct {
@@ -39,5 +40,13 @@ func unmarshalConfig(b []byte) (*Config, error) {
 	if config.SessionHeader == "" {
 		config.SessionHeader = "X-Kuiperbelt-Session"
 	}
+	if config.Endpoint == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			return nil, err
+		}
+		config.Endpoint = hostname
+	}
+
 	return &config, nil
 }

--- a/server.go
+++ b/server.go
@@ -10,6 +10,10 @@ import (
 	"golang.org/x/net/websocket"
 )
 
+const (
+	ENDPOINT_HEADER_NAME = "X-Kuiperbelt-Endpoint"
+)
+
 var (
 	sessionKeyNotExistError            = errors.New("session key is not exist.")
 	connectCallbackIsNotAvailableError = errors.New("connect callback is not available.")
@@ -63,6 +67,7 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 		return nil, ConnectCallbackError{http.StatusInternalServerError, err}
 	}
 	callbackRequest.Header = r.Header
+	callbackRequest.Header.Add(ENDPOINT_HEADER_NAME, s.Config.Endpoint)
 	resp, err := callbackClient.Do(callbackRequest)
 	if err != nil {
 		return nil, ConnectCallbackError{http.StatusBadGateway, connectCallbackIsNotAvailableError}

--- a/server_test.go
+++ b/server_test.go
@@ -14,14 +14,14 @@ const (
 )
 
 type testSuccessConnectCallbackServer struct {
-	SessionKey   string
 	IsCallbacked bool
+	Header       http.Header
 }
 
 func (s *testSuccessConnectCallbackServer) SuccessHandler(w http.ResponseWriter, r *http.Request) {
 	s.IsCallbacked = true
 	key := r.Header.Get(testRequestSessionHeader)
-	s.SessionKey = key
+	s.Header = r.Header
 	w.Header().Add(TestConfig.SessionHeader, "hogehoge")
 	w.WriteHeader(http.StatusOK)
 }
@@ -79,8 +79,17 @@ func TestWebSocketServer__Handler__SuccessAuthorized(t *testing.T) {
 	if !callbackServer.IsCallbacked {
 		t.Error("callback server doesn't receive request")
 	}
-	if callbackServer.SessionKey != "hogehoge" {
-		t.Error("callback server doesn't receive session key:", callbackServer.SessionKey)
+	if callbackServer.Header.Get(testRequestSessionHeader) != "hogehoge" {
+		t.Error(
+			"callback server doesn't receive session key:",
+			callbackServer.Header.Get(testRequestSessionHeader),
+		)
+	}
+	if callbackServer.Header.Get(ENDPOINT_HEADER_NAME) != c.Endpoint {
+		t.Error(
+			"callback server doesn't receive endpoint name:",
+			callbackServer.Header.Get(testRequestSessionHeader),
+		)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -20,7 +20,6 @@ type testSuccessConnectCallbackServer struct {
 
 func (s *testSuccessConnectCallbackServer) SuccessHandler(w http.ResponseWriter, r *http.Request) {
 	s.IsCallbacked = true
-	key := r.Header.Get(testRequestSessionHeader)
 	s.Header = r.Header
 	w.Header().Add(TestConfig.SessionHeader, "hogehoge")
 	w.WriteHeader(http.StatusOK)
@@ -28,8 +27,7 @@ func (s *testSuccessConnectCallbackServer) SuccessHandler(w http.ResponseWriter,
 
 func (s *testSuccessConnectCallbackServer) FailHandler(w http.ResponseWriter, r *http.Request) {
 	s.IsCallbacked = true
-	key := r.Header.Get(testRequestSessionHeader)
-	s.SessionKey = key
+	s.Header = r.Header
 	w.WriteHeader(http.StatusForbidden)
 	io.WriteString(w, "fail authorization!")
 }


### PR DESCRIPTION
## Usage

### configuration
```yaml
session_header: "X-Kuiperbelt-Session-Key"
port: 12345
endpoint: "localhost"
callback:
  connect: "http://localhost:12346/connect"
  receive: "http://localhost:12346/receive"
```

`endpoint` is not required. Default value is `os.Hostname()`.

### request header of connection callback
```
X-Kuiperbelt-Session-Key: hogehoge
X-Kuiperbelt-Endpoint: localhost
```