### PR TITLE
add: close callback

### DIFF
--- a/_example/app.psgi
+++ b/_example/app.psgi
@@ -33,6 +33,17 @@ $router->add("/connect", sub {
     return ["200", ["X-Kuiperbelt-Session" => $session], ["joined success"]];
 });
 
+$router->add("/close", sub {
+    my $env = shift;
+    my $req = Plack::Request->new($env);
+
+    my @session = $req->header("X-Kuiperbelt-Session");
+
+    $redis->srem("sessions", @session);
+
+    return ["200", [], ["success closed"]];
+});
+
 $router->add("/recent", sub {
     my $env = shift;
     my $req = Plack::Request->new($env);

--- a/_example/config.yml
+++ b/_example/config.yml
@@ -1,4 +1,4 @@
 port: 12345
 callback:
   connect: "http://localhost:12346/connect"
-  receive: "http://localhost:12346/receive"
+  close: "http://localhost:12346/close"

--- a/cmd/ekbo/config.yml
+++ b/cmd/ekbo/config.yml
@@ -1,4 +1,3 @@
 port: 12345
 callback:
   connect: "http://localhost:12346/connect"
-  receive: "http://localhost:12346/receive"

--- a/config.go
+++ b/config.go
@@ -19,7 +19,7 @@ type Config struct {
 
 type Callback struct {
 	Connect string `yaml:"connect"`
-	Receive string `yaml:"receive"`
+	Close   string `yaml:"close"`
 }
 
 func NewConfig(filename string) (*Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -10,14 +10,13 @@ session_header: "X-Kuiperbelt-Session-Key"
 port: 12345
 callback:
   connect: "http://localhost:12346/connect"
-  receive: "http://localhost:12346/receive"
 `)
 var TestConfig = Config{
 	Port:          ":12345",
 	SessionHeader: "X-Kuiperbelt-Session-Key",
 	Callback: Callback{
 		Connect: "http://localhost:12346/connect",
-		Receive: "http://localhost:12346/receive",
+		Close:   "",
 	},
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -144,6 +144,7 @@ func (p *Proxy) closeSession(s Session, bs []byte) {
 	if err != nil {
 		return
 	}
+	s.NotifiedClose(true)
 	err = s.Close()
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 func TestProxySendHandlerFunc__BulkSend(t *testing.T) {
-	s1 := &TestSession{new(bytes.Buffer), "hogehoge", false}
-	s2 := &TestSession{new(bytes.Buffer), "fugafuga", false}
+	s1 := &TestSession{new(bytes.Buffer), "hogehoge", false, false}
+	s2 := &TestSession{new(bytes.Buffer), "fugafuga", false, false}
 
 	AddSession(s1)
 	AddSession(s2)
@@ -55,8 +55,8 @@ func TestProxySendHandlerFunc__BulkSend(t *testing.T) {
 }
 
 func TestProxyCloseHandlerFunc__BulkClose(t *testing.T) {
-	s1 := &TestSession{new(bytes.Buffer), "hogehoge", false}
-	s2 := &TestSession{new(bytes.Buffer), "fugafuga", false}
+	s1 := &TestSession{new(bytes.Buffer), "hogehoge", false, false}
+	s2 := &TestSession{new(bytes.Buffer), "fugafuga", false, false}
 
 	AddSession(s1)
 	AddSession(s2)

--- a/session.go
+++ b/session.go
@@ -15,6 +15,7 @@ var (
 type Session interface {
 	io.ReadWriteCloser
 	Key() string
+	NotifiedClose(bool)
 }
 
 func AddSession(s Session) {

--- a/session_test.go
+++ b/session_test.go
@@ -6,8 +6,9 @@ import (
 
 type TestSession struct {
 	*bytes.Buffer
-	key      string
-	isClosed bool
+	key             string
+	isClosed        bool
+	isNotifiedClose bool
 }
 
 func (s *TestSession) Key() string {
@@ -17,4 +18,8 @@ func (s *TestSession) Key() string {
 func (s *TestSession) Close() error {
 	s.isClosed = true
 	return nil
+}
+
+func (s *TestSession) NotifiedClose(isNotified bool) {
+	s.isNotifiedClose = isNotified
 }


### PR DESCRIPTION
### Usage
- add `close` url at config
```yaml
callback:
  close: "http://localhost:12346/close"
```

- implement callback

example:
```perl
$router->add("/close", sub {
    my $env = shift;
    my $req = Plack::Request->new($env);

    # injected key of closed session in header
    my @session = $req->header("X-Kuiperbelt-Session");

    $redis->srem("sessions", @session);

    return ["200", [], ["success closed"]];
});
```