### PR TITLE
Content-Type is not case sensitive.

### DIFF
--- a/proxy_test.go
+++ b/proxy_test.go
@@ -95,7 +95,7 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 	if err != nil {
 		t.Fatal("creadrequest unexpected error:", err)
 	}
-	req.Header.Add("Content-Type", "application/octet-stream")
+	req.Header.Add("Content-Type", "APPLICATION/octet-stream ;param=foobar")
 	req.Header.Add(tc.SessionHeader, "hogehoge")
 	_, err = http.DefaultClient.Do(req)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -260,7 +260,12 @@ func messageMarshal(v interface{}) ([]byte, byte, error) {
 	}
 
 	payloadType := byte(websocket.TextFrame)
-	if message.contentType == "application/octet-stream" {
+	contentType := message.contentType
+	if i := strings.Index(contentType, ";"); i >= 0 {
+		contentType = contentType[0:i]
+	}
+	contentType = strings.TrimSpace(contentType)
+	if strings.EqualFold(contentType, "application/octet-stream") {
 		payloadType = websocket.BinaryFrame
 	}
 


### PR DESCRIPTION
> http://www.w3.org/Protocols/rfc1341/4_Content-Type.html
> The type, subtype, and parameter names are not case sensitive. For example, TEXT, Text, and TeXt are all equivalent.

気になったから直してみたけど、正直こんなの送りつけてくるサーバは存在するのだろうか