### PR TITLE
add: `strict_broadcast` option in config.

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,11 +10,12 @@ import (
 )
 
 type Config struct {
-	Callback      Callback `yaml:"callback"`
-	SessionHeader string   `yaml:"session_header"`
-	Port          string   `yaml:"port"`
-	Sock          string   `yaml:"sock"`
-	Endpoint      string   `yaml:"endpoint"`
+	Callback        Callback `yaml:"callback"`
+	SessionHeader   string   `yaml:"session_header"`
+	Port            string   `yaml:"port"`
+	Sock            string   `yaml:"sock"`
+	Endpoint        string   `yaml:"endpoint"`
+	StrictBroadcast bool     `yaml:"strict_broadcast"`
 }
 
 type Callback struct {


### PR DESCRIPTION
### Example

`A` client is connected to kuiperbelt. `B` client is closed connection already.
Backend send broadcast message to `A` and `B`.

#### strict_broadcast=false

`A` receive message. Kuiperbelt return `status=200` JSON response to backend.
`session is not found.` error message into response.  This message has error session key.
```
$ curl -XPOST -H"X-Kuiperbelt-Session: A" -H"X-Kuiperbelt-Session: B" -d "hogehoge" http://localhost:12345/send
{"errors":[{"error":"session is not found.","session":"B"}],"result":"OK"}
```

#### strict_broadcast=true

`A` cannot receive message. Kuiperbelt return `status=400` JSON response to backend.
```
$ curl -XPOST -H"X-Kuiperbelt-Session: A" -H"X-Kuiperbelt-Session: B" -d "hogehoge" http://localhost:12345/send
{"errors":[{"error":"session is not found.","session":"B"}],"result":"NG"}
```