### PR TITLE
Output stats by Sensu/Mackerel metrics format

### DIFF
--- a/server.go
+++ b/server.go
@@ -89,8 +89,16 @@ func (s *WebSocketServer) Register() {
 }
 
 func (s *WebSocketServer) StatsHandler(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	err := s.Stats.Dump(w)
+	var err error
+
+	switch r.FormValue("format") {
+	case "tsv", "txt", "text":
+		w.Header().Set("Content-Type", "text/plain")
+		err = s.Stats.DumpText(w)
+	default:
+		w.Header().Set("Content-Type", "application/json")
+		err = s.Stats.Dump(w)
+	}
 	if err != nil {
 		log.WithFields(log.Fields{
 			"error": err.Error(),

--- a/stats.go
+++ b/stats.go
@@ -1,9 +1,12 @@
 package kuiperbelt
 
 import (
+	"bufio"
 	"encoding/json"
+	"fmt"
 	"io"
 	"sync/atomic"
+	"time"
 )
 
 type Stats struct {
@@ -20,6 +23,17 @@ func NewStats() *Stats {
 
 func (s *Stats) Dump(w io.Writer) error {
 	return json.NewEncoder(w).Encode(s)
+}
+
+func (s *Stats) DumpText(w io.Writer) error {
+	now := time.Now().Unix()
+	_w := bufio.NewWriter(w)
+	fmt.Fprintf(_w, "kuiperbelt.connections\t%d\t%d\n", s.Connections, now)
+	fmt.Fprintf(_w, "kuiperbelt.total_connections\t%d\t%d\n", s.TotalConnections, now)
+	fmt.Fprintf(_w, "kuiperbelt.total_messages\t%d\t%d\n", s.TotalMessages, now)
+	fmt.Fprintf(_w, "kuiperbelt.connect_errors\t%d\t%d\n", s.ConnectErrors, now)
+	fmt.Fprintf(_w, "kuiperbelt.message_errors\t%d\t%d\n", s.MessageErrors, now)
+	return _w.Flush()
 }
 
 func (s *Stats) ConnectEvent() {

--- a/stats_test.go
+++ b/stats_test.go
@@ -42,6 +42,13 @@ func TestStats(t *testing.T) {
 	if out.String() != `{"connections":5,"total_connections":10,"total_messages":4,"connect_errors":3,"message_errors":2}`+"\n" {
 		t.Errorf("unexpected dump JSON %s", out.String())
 	}
+
+	text := new(bytes.Buffer)
+	err = s.DumpText(text)
+	if err != nil {
+		t.Errorf("stats dump text failed %s", err)
+	}
+	t.Log(text.String())
 }
 
 func TestStatsRace(t *testing.T) {


### PR DESCRIPTION
Kuiperbelt outputs stats by Sensu/Mackerel metrics format when URL arguments includes`format=text`.

For example, 

```
kuiperbelt.connections	0	1479361900
kuiperbelt.total_connections	2	1479361900
kuiperbelt.total_messages	2	1479361900
kuiperbelt.connect_errors	0	1479361900
kuiperbelt.message_errors	0	1479361900
```