### PR TITLE
use io.CopyBuffer

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -16,6 +16,10 @@ var (
 	cannotSendMessageError = errors.New("cannot send messages.")
 )
 
+const (
+	ioBufferSize = 4096
+)
+
 type cannotFindSessionKeysError []sessionError
 
 func (e cannotFindSessionKeysError) Error() string {
@@ -115,7 +119,8 @@ func (p *Proxy) SendHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	b := new(bytes.Buffer)
-	_, err = io.Copy(b, r.Body)
+	buf := make([]byte, ioBufferSize)
+	_, err = io.CopyBuffer(b, r.Body, buf)
 	if err != nil {
 	}
 	message := &Message{
@@ -145,7 +150,8 @@ func (p *Proxy) CloseHandlerFunc(w http.ResponseWriter, r *http.Request) {
 	}
 
 	b := new(bytes.Buffer)
-	_, err = io.Copy(b, r.Body)
+	buf := make([]byte, ioBufferSize)
+	_, err = io.CopyBuffer(b, r.Body, buf)
 	if err != nil {
 	}
 	message := &Message{

--- a/server.go
+++ b/server.go
@@ -232,7 +232,8 @@ func (s *WebSocketSession) WaitClose() {
 func (s *WebSocketSession) WatchClose() {
 	defer s.Close()
 	defer func() { go s.SendCloseCallback() }()
-	_, err := io.Copy(new(blackholeWriter), s)
+	buf := make([]byte, ioBufferSize)
+	_, err := io.CopyBuffer(new(blackholeWriter), s, buf)
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
io.Copy makes 32KB buffer automatically, but it is too large for kuiperbelt use case.
This PR makes 4KB buffer and use it with io.CopyBuffer.