### PR TITLE
Change dependence websocket library. golang.org/x/net/websocket to gorilla/websocket

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,12 +32,6 @@
   revision = "dadca013650a921313c28fa51e4e89e84e3e252d"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/net"
-  packages = ["websocket"]
-  revision = "1961d9def2b2d7a28d7958926d2457d05a178ecd"
-
-[[projects]]
   branch = "v1"
   name = "gopkg.in/yaml.v1"
   packages = ["."]
@@ -46,6 +40,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6ff859a933cacd0f67b8b1d00f3ef3d9e16ff4e06cd205b70a29ddd109edddd1"
+  inputs-digest = "ee784cb9ade8effba2dc94ef4f984083d4749d60f05a1a172940698150b5526e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,6 +8,12 @@
   version = "v0.3.1"
 
 [[projects]]
+  name = "github.com/gorilla/websocket"
+  packages = ["."]
+  revision = "ea4d1f681babbce9545c9c5f3d5194a789c89f5b"
+  version = "v1.2.0"
+
+[[projects]]
   name = "go.uber.org/atomic"
   packages = ["."]
   revision = "4e336646b2ef9fc6e47be8e21594178f98e5ebcf"
@@ -40,6 +46,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8926c73575ee41dfce5e40366f6f43fd5069471b53c381209db226bc2eedfbb1"
+  inputs-digest = "6ff859a933cacd0f67b8b1d00f3ef3d9e16ff4e06cd205b70a29ddd109edddd1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -86,7 +86,7 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 	th := httptest.NewServer(http.HandlerFunc(server.Handler))
 
 	wsURL := strings.Replace(th.URL, "http://", "ws://", -1)
-	wsConfig, err := xws.NewConfig(wsURL, "http://localhost/")
+	wsConfig, err := xws.NewConfig(wsURL, th.URL)
 	if err != nil {
 		t.Fatal("cannot create connection config error:", err)
 	}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"golang.org/x/net/websocket"
+	xws "golang.org/x/net/websocket"
 )
 
 func TestProxySendHandlerFunc__BulkSend(t *testing.T) {
@@ -86,21 +86,21 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 	th := httptest.NewServer(http.HandlerFunc(server.Handler))
 
 	wsURL := strings.Replace(th.URL, "http://", "ws://", -1)
-	wsConfig, err := websocket.NewConfig(wsURL, "http://localhost/")
+	wsConfig, err := xws.NewConfig(wsURL, "http://localhost/")
 	if err != nil {
 		t.Fatal("cannot create connection config error:", err)
 	}
 	wsConfig.Header.Add(testRequestSessionHeader, "hogehoge")
-	conn, err := websocket.DialConfig(wsConfig)
+	conn, err := xws.DialConfig(wsConfig)
 	if err != nil {
 		t.Fatal("cannot connect error:", err)
 	}
 
 	// ignore hello message
 	var hello string
-	websocket.Message.Receive(conn, &hello)
+	xws.Message.Receive(conn, &hello)
 
-	codec := &websocket.Codec{
+	codec := &xws.Codec{
 		Unmarshal: func(data []byte, payloadType byte, v interface{}) error {
 			rb, _ := v.(*byte)
 			*rb = payloadType
@@ -122,7 +122,7 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 
 	var rb byte
 	codec.Receive(conn, &rb)
-	if rb != websocket.BinaryFrame {
+	if rb != xws.BinaryFrame {
 		t.Fatal("receved message is not binary frame:", rb)
 	}
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	xws "golang.org/x/net/websocket"
+	"github.com/gorilla/websocket"
 )
 
 func TestProxySendHandlerFunc__BulkSend(t *testing.T) {
@@ -86,28 +86,13 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 	th := httptest.NewServer(http.HandlerFunc(server.Handler))
 
 	wsURL := strings.Replace(th.URL, "http://", "ws://", -1)
-	wsConfig, err := xws.NewConfig(wsURL, th.URL)
+	dialer := websocket.Dialer{}
+	conn, _, err := dialer.Dial(wsURL, http.Header{testRequestSessionHeader: []string{"hogehoge"}})
 	if err != nil {
 		t.Fatal("cannot create connection config error:", err)
 	}
-	wsConfig.Header.Add(testRequestSessionHeader, "hogehoge")
-	conn, err := xws.DialConfig(wsConfig)
-	if err != nil {
-		t.Fatal("cannot connect error:", err)
-	}
 
-	// ignore hello message
-	var hello string
-	xws.Message.Receive(conn, &hello)
-
-	codec := &xws.Codec{
-		Unmarshal: func(data []byte, payloadType byte, v interface{}) error {
-			rb, _ := v.(*byte)
-			*rb = payloadType
-			return nil
-		},
-		Marshal: nil,
-	}
+	conn.ReadMessage() // ignore hello message
 
 	req, err := http.NewRequest("POST", ts.URL, bytes.NewBuffer([]byte("hogehoge")))
 	if err != nil {
@@ -120,10 +105,12 @@ func TestProxySendHandlerFunc__SendInBinary(t *testing.T) {
 		t.Fatal("send request unexpected error:", err)
 	}
 
-	var rb byte
-	codec.Receive(conn, &rb)
-	if rb != xws.BinaryFrame {
-		t.Fatal("receved message is not binary frame:", rb)
+	messageType, _, err := conn.ReadMessage()
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	}
+	if messageType != websocket.BinaryMessage {
+		t.Errorf("receved message is not binary frame: %d", messageType)
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -208,7 +208,7 @@ func TestWebSocketServer__Handler__CloseByClient(t *testing.T) {
 	tc := httptest.NewServer(http.HandlerFunc(server.Handler))
 
 	wsURL := strings.Replace(tc.URL, "http://", "ws://", -1)
-	wsConfig, err := xws.NewConfig(wsURL, "http://localhost/")
+	wsConfig, err := xws.NewConfig(wsURL, tc.URL)
 	if err != nil {
 		t.Fatal("cannot create connection config error:", err)
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -189,7 +189,7 @@ func TestWebSocketServer__Handler__FailAuthorized(t *testing.T) {
 	b.ReadFrom(resp.Body)
 
 	if b.String() != "fail authorization!" {
-		t.Error("callback message is not in response")
+		t.Errorf("callback message is not in response: %s", b.String())
 	}
 }
 

--- a/server_test.go
+++ b/server_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/net/websocket"
+	xws "golang.org/x/net/websocket"
 )
 
 const (
@@ -208,12 +208,12 @@ func TestWebSocketServer__Handler__CloseByClient(t *testing.T) {
 	tc := httptest.NewServer(http.HandlerFunc(server.Handler))
 
 	wsURL := strings.Replace(tc.URL, "http://", "ws://", -1)
-	wsConfig, err := websocket.NewConfig(wsURL, "http://localhost/")
+	wsConfig, err := xws.NewConfig(wsURL, "http://localhost/")
 	if err != nil {
 		t.Fatal("cannot create connection config error:", err)
 	}
 	wsConfig.Header.Add(testRequestSessionHeader, "hogehoge")
-	conn, err := websocket.DialConfig(wsConfig)
+	conn, err := xws.DialConfig(wsConfig)
 	if err != nil {
 		t.Fatal("cannot connect error:", err)
 	}


### PR DESCRIPTION
## Reason

- The golang.org/x/net/websocket looks like few maintenance activity.
https://godoc.org/golang.org/x/net/websocket
> This package currently lacks some features found in an alternative and more actively maintained WebSocket package:

- I need implement that idle timeout at a session. But the x/net/websocket is not supported that Ping/Pong control by library user. The gorilla/websocket is supported this.