### PR TITLE
Add callback.timeout configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ callback:
   # When your application returning "HTTP/1.1 OK 200" in this callback, a connection upgrade to WebSocket.
   # However your returning other than "200" ("404", "403" and "500"...), a connection is disconnect.
   connect: "http://localhost:12346/connect"
+  timeout: 10s    # callback response timeout
 proxy_set_header:
   "X-Foo": "Foo"  # set to callback request header
   "X-Bar": ""     # remove from callback request header

--- a/config.go
+++ b/config.go
@@ -41,8 +41,9 @@ type Config struct {
 }
 
 type Callback struct {
-	Connect string `yaml:"connect"`
-	Close   string `yaml:"close"`
+	Connect string        `yaml:"connect"`
+	Close   string        `yaml:"close"`
+	Timeout time.Duration `yaml:"timeout"`
 }
 
 func NewConfig(filename string) (*Config, error) {

--- a/config_test.go
+++ b/config_test.go
@@ -11,6 +11,7 @@ session_header: "X-Kuiperbelt-Session-Key"
 port: 12345
 callback:
   connect: "http://localhost:12346/connect"
+  timeout: 5s
 send_timeout: 1s
 send_queue_size: 1
 `)
@@ -20,6 +21,7 @@ var TestConfig = Config{
 	Callback: Callback{
 		Connect: "http://localhost:12346/connect",
 		Close:   "",
+		Timeout: time.Second * 5,
 	},
 	SendTimeout:   time.Second,
 	SendQueueSize: 1,

--- a/server.go
+++ b/server.go
@@ -154,6 +154,13 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return nil, err
 	}
+	// set callback timeout
+	if timeout := s.Config.Callback.Timeout; timeout != 0 {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		callbackRequest = callbackRequest.WithContext(ctx)
+	}
+
 	// copy all headers except "Connection", "Upgrade" and "Sec-Websocket*"
 	for n, values := range r.Header {
 		n := strings.ToLower(n)

--- a/server.go
+++ b/server.go
@@ -154,12 +154,6 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return nil, err
 	}
-	// set callback timeout
-	if timeout := s.Config.Callback.Timeout; timeout != 0 {
-		ctx, cancel := context.WithTimeout(r.Context(), timeout)
-		defer cancel()
-		callbackRequest = callbackRequest.WithContext(ctx)
-	}
 
 	// copy all headers except "Connection", "Upgrade" and "Sec-Websocket*"
 	for n, values := range r.Header {
@@ -182,6 +176,13 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 	}
 
 	callbackRequest.Header.Add(ENDPOINT_HEADER_NAME, s.Config.Endpoint)
+
+	// set callback timeout
+	if timeout := s.Config.Callback.Timeout; timeout != 0 {
+		ctx, cancel := context.WithTimeout(r.Context(), timeout)
+		defer cancel()
+		callbackRequest = callbackRequest.WithContext(ctx)
+	}
 	resp, err := callbackClient.Do(callbackRequest)
 	if err != nil {
 		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)


### PR DESCRIPTION
This is useful for stopping a callback request to dead endpoint.