### PR TITLE
Path prefix

### DIFF
--- a/config.go
+++ b/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	OriginPolicy      string            `yaml:"origin_policy"`
 	IdleTimeout       time.Duration     `yaml:"idle_timeout"`
 	SuppressAccessLog bool              `yaml:"suppress_access_log"`
+	PathPrefix        string            `yaml:"path_prefix"`
 }
 
 type Callback struct {

--- a/proxy.go
+++ b/proxy.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"path"
 	"sync"
 )
 
@@ -42,9 +43,10 @@ func NewProxy(c Config, s *Stats, p *SessionPool) *Proxy {
 
 func (p *Proxy) Register() {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/send", p.SendHandlerFunc)
-	mux.HandleFunc("/close", p.CloseHandlerFunc)
-	mux.HandleFunc("/ping", p.PingHandlerFunc)
+	prefix := p.Config.PathPrefix
+	mux.HandleFunc(path.Join(prefix, "/send"), p.SendHandlerFunc)
+	mux.HandleFunc(path.Join(prefix, "/close"), p.CloseHandlerFunc)
+	mux.HandleFunc(path.Join(prefix, "/ping"), p.PingHandlerFunc)
 	if p.Config.SuppressAccessLog {
 		http.Handle("/", mux)
 	} else {

--- a/server.go
+++ b/server.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -121,8 +122,9 @@ func (s *WebSocketServer) Register() {
 	callbackClient.Transport = &http.Transport{
 		MaxIdleConnsPerHost: CALLBACK_CLIENT_MAX_CONNS_PER_HOST,
 	}
-	http.HandleFunc("/connect", s.Handler)
-	http.HandleFunc("/stats", s.StatsHandler)
+	prefix := s.Config.PathPrefix
+	http.HandleFunc(path.Join(prefix, "/connect"), s.Handler)
+	http.HandleFunc(path.Join(prefix, "/stats"), s.StatsHandler)
 }
 
 func (s *WebSocketServer) StatsHandler(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
### What's this?

- add `path_prefix` option in config.yml. Ex. `path_prefix: /ws`.
- This option add prefix to API path(`/connect`, `/send`, etc...) if you set this option. 