### PR TITLE
Close TCP connections to backend periodically.

### DIFF
--- a/server.go
+++ b/server.go
@@ -180,6 +180,7 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 	}
 
 	callbackRequest.Header.Add(ENDPOINT_HEADER_NAME, s.Config.Endpoint)
+	callbackRequest.Close = s.shouldCloseCallbackRequest()
 
 	// set callback timeout
 	if timeout := s.Config.Callback.Timeout; timeout != 0 {
@@ -192,7 +193,6 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
 		return nil, err
 	}
-	callbackRequest.Close = s.shouldCloseCallbackRequest()
 
 	if resp.StatusCode != http.StatusOK {
 		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))

--- a/server.go
+++ b/server.go
@@ -24,8 +24,9 @@ const (
 )
 
 var (
-	callbackClient  = new(http.Client)
-	defaultUpgrader = websocket.Upgrader{
+	callbackClient        = new(http.Client)
+	callbackCloseInterval = 10 * time.Second
+	defaultUpgrader       = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
 	}
@@ -42,6 +43,7 @@ type WebSocketServer struct {
 	Stats    *Stats
 	Pool     *SessionPool
 	upgrader websocket.Upgrader
+	timer    *time.Timer
 }
 
 func NewWebSocketServer(c Config, s *Stats, p *SessionPool) *WebSocketServer {
@@ -78,6 +80,7 @@ func NewWebSocketServer(c Config, s *Stats, p *SessionPool) *WebSocketServer {
 		Stats:    s,
 		Pool:     p,
 		upgrader: upgrader,
+		timer:    time.NewTimer(callbackCloseInterval),
 	}
 }
 
@@ -120,6 +123,7 @@ func (s *WebSocketServer) Handler(w http.ResponseWriter, r *http.Request) {
 func (s *WebSocketServer) Register() {
 	callbackClient.Transport = &http.Transport{
 		MaxIdleConnsPerHost: CALLBACK_CLIENT_MAX_CONNS_PER_HOST,
+		IdleConnTimeout:     callbackCloseInterval,
 	}
 	http.HandleFunc("/connect", s.Handler)
 	http.HandleFunc("/stats", s.StatsHandler)
@@ -188,6 +192,7 @@ func (s *WebSocketServer) ConnectCallbackHandler(w http.ResponseWriter, r *http.
 		http.Error(w, http.StatusText(http.StatusBadGateway), http.StatusBadGateway)
 		return nil, err
 	}
+	callbackRequest.Close = s.shouldCloseCallbackRequest()
 
 	if resp.StatusCode != http.StatusOK {
 		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
@@ -294,6 +299,17 @@ func (s *WebSocketServer) Shutdown(ctx context.Context) error {
 	return nil
 }
 
+func (s *WebSocketServer) shouldCloseCallbackRequest() bool {
+	select {
+	case <-s.timer.C:
+		Log.Debug("shouldCloseCallbackRequest")
+		s.timer.Reset(callbackCloseInterval)
+		return true
+	default:
+		return false
+	}
+}
+
 type WebSocketSession struct {
 	ws       *websocket.Conn
 	key      string
@@ -353,6 +369,7 @@ func (s *WebSocketSession) sendCloseCallback() {
 			req.Header.Set(name, value)
 		}
 	}
+	req.Close = s.server.shouldCloseCallbackRequest()
 	resp, err := callbackClient.Do(req)
 
 	if err != nil {


### PR DESCRIPTION
callbackClient keep alive a TCP connection to backend servers for a long time by default settings.
But we should clean up the TCP connections periodically because backend servers are scaling up and down or refreshing.